### PR TITLE
Add Banrisul validation

### DIFF
--- a/spec/banrisul_check_number_calculator.spec.js
+++ b/spec/banrisul_check_number_calculator.spec.js
@@ -1,0 +1,40 @@
+describe("BanrisulCheckNumberCalculator", function() {
+
+  var bankAccount;
+
+  beforeEach(function() { 
+    bankAccount = {
+      accountNumber      : "358507671",
+      accountCheckNumber : "8"
+    };
+
+    bankAccountModuleOne = {
+      accountNumber      : "358507670",
+      accountCheckNumber : "6"
+    };
+
+    bankAccountModuleZero = {
+      accountNumber      : "358507675",
+      accountCheckNumber : "0"
+    };
+  });
+
+  describe("validate Banrisul account number", function() {
+
+    it("should correctly calculate the check number", function() {
+      checkNumberCalculated = Moip.BanrisulCheckNumberCalculator.calculate(bankAccount.accountNumber);
+      expect(checkNumberCalculated).toEqual(bankAccount.accountCheckNumber);
+    });
+
+    it("should correctly calculate the check number with module one", function() {
+      checkNumberCalculated = Moip.BanrisulCheckNumberCalculator.calculate(bankAccountModuleOne.accountNumber);
+      expect(checkNumberCalculated).toEqual(bankAccountModuleOne.accountCheckNumber);
+    });
+
+    it("should correctly calculate the check number with module zero", function() {
+      checkNumberCalculated = Moip.BanrisulCheckNumberCalculator.calculate(bankAccountModuleZero.accountNumber);
+      expect(checkNumberCalculated).toEqual(bankAccountModuleZero.accountCheckNumber);
+    });
+  });
+
+});

--- a/spec/banrisul_validator.spec.js
+++ b/spec/banrisul_validator.spec.js
@@ -1,0 +1,88 @@
+describe("BanrisulValidator", function() {
+
+  var bankAccount;
+
+  beforeEach(function() { 
+    bankAccount = {
+      bankNumber         : "041",
+      agencyNumber       : "1234",
+      agencyCheckNumber  : "",
+      accountNumber      : "358507671",
+      accountCheckNumber : "8",
+      valid: jasmine.createSpy(),
+      invalid: jasmine.createSpy()
+    };
+  });
+
+
+  describe("validate agency number", function(){
+
+    it("does NOT accept invalid agency", function() {
+      bankAccount.agencyNumber = "333123";
+      bankAccount.accountCheckNumber = "1";
+      Moip.BankAccount.validate(bankAccount);
+      var expectedParams = { errors: [{ 
+        description: 'A agência deve conter 4 números. Complete com zeros a esquerda se necessário.', 
+        code: 'INVALID_AGENCY_NUMBER' 
+      },{
+        description: 'Dígito da conta não corresponde ao número da conta/agência preenchido', 
+        code: 'ACCOUNT_CHECK_NUMBER_DONT_MATCH' 
+      }]};
+      expect(bankAccount.invalid).toHaveBeenCalledWith(expectedParams);
+    });
+
+  });
+
+  describe("validate agency check number", function(){
+
+    it("does NOT accept agency check number", function() {
+      bankAccount.agencyCheckNumber = "1";
+      Moip.BankAccount.validate(bankAccount);
+      var expectedParams = { errors: [{ 
+        description: 'O dígito da agência deve ser vazio', 
+        code: 'INVALID_AGENCY_CHECK_NUMBER' 
+      }]};
+      expect(bankAccount.invalid).toHaveBeenCalledWith(expectedParams);
+    });
+  });
+
+  describe("validate account number", function(){
+
+    it("accepts a valid bank account", function() {
+      Moip.BankAccount.validate(bankAccount);
+      expect(bankAccount.valid).toHaveBeenCalled();
+    });
+
+    it("does NOT accept account less than nine digits", function() {
+      bankAccount.accountNumber = "1234";
+      Moip.BankAccount.validate(bankAccount);
+      var expectedParams = { errors: [{ 
+        description: 'A conta corrente deve conter 9 números. Complete com zeros a esquerda se necessário.', 
+        code: 'INVALID_ACCOUNT_NUMBER' 
+      }]};
+      expect(bankAccount.invalid).toHaveBeenCalledWith(expectedParams);
+    });
+
+    it("does NOT accept account greater than nine digits", function() {
+      bankAccount.accountNumber = "1234567890";
+      Moip.BankAccount.validate(bankAccount);
+      var expectedParams = { errors: [{ 
+        description: 'A conta corrente deve conter 9 números. Complete com zeros a esquerda se necessário.', 
+        code: 'INVALID_ACCOUNT_NUMBER' 
+      }]};
+      expect(bankAccount.invalid).toHaveBeenCalledWith(expectedParams);
+    });
+
+    it("does NOT accept when calc account check number invalid", function() {
+      bankAccount.accountCheckNumber = "0";
+      Moip.BankAccount.validate(bankAccount);
+      var expectedParams = { errors: [{ 
+        description: 'Dígito da conta não corresponde ao número da conta/agência preenchido', 
+        code: 'ACCOUNT_CHECK_NUMBER_DONT_MATCH' 
+      }]};
+      expect(bankAccount.invalid).toHaveBeenCalledWith(expectedParams);
+    });
+
+  });
+
+});

--- a/src/bank_account.js
+++ b/src/bank_account.js
@@ -18,7 +18,8 @@
         "341": Moip.ItauValidator,
         "033": Moip.SantanderValidator,
         "745": Moip.CitibankValidator,
-        "399": Moip.HSBCValidator
+        "399": Moip.HSBCValidator,
+        "041": Moip.BanrisulValidator
       };
 
       if (validators[bankNumber]) {

--- a/src/banrisul_check_number_calculator.js
+++ b/src/banrisul_check_number_calculator.js
@@ -1,0 +1,43 @@
+(function(window) {
+  var Moip = window.Moip || {};
+  window.Moip = Moip;
+
+  function BanrisulCheckNumberCalculator() {
+    if ( !( this instanceof BanrisulCheckNumberCalculator ) ) {
+      return new BanrisulCheckNumberCalculator();
+    }
+  }
+
+  BanrisulCheckNumberCalculator.prototype = {
+
+    calculate: function(accountNumber) {
+      var numbers = accountNumber.split("");
+      var sumSeq = 0;
+      
+      for (var i = 0; i < numbers.length; i++) {
+        var number = parseInt(numbers[i]);
+        sumSeq += this.multiplyAccordingWeight(number, i);
+      }
+
+      return this.moduleEleven(sumSeq).toString();
+    },
+
+    multiplyAccordingWeight: function(number, index) {
+      var weight = [3,2,4,7,6,5,4,3,2];
+      return number * weight[index];
+    },
+
+    moduleEleven: function(sumSeq) {
+      var module = sumSeq % 11;
+      if (module === 0) {
+        return 0;
+      } else if (module == 1) {
+        return 6;
+      }
+      return 11 - module;
+    }
+  };
+
+  Moip.BanrisulCheckNumberCalculator = BanrisulCheckNumberCalculator();
+
+})(window);

--- a/src/banrisul_validator.js
+++ b/src/banrisul_validator.js
@@ -1,0 +1,56 @@
+(function(window) {
+  var Moip = window.Moip || {};
+  window.Moip = Moip;
+
+  function BanrisulValidator() {
+    if ( !( this instanceof BanrisulValidator ) ) {
+      return new BanrisulValidator();
+    }
+  }
+
+  BanrisulValidator.prototype = {
+    agencyNumberIsValid: function(agencyNumber) {
+      return Moip.CommonBankAccountValidator.agencyNumberIsValid(agencyNumber);
+    },
+
+    agencyCheckNumberIsValid: function(agencyCheckNumber) {
+      return agencyCheckNumber === undefined || agencyCheckNumber === "";
+    },
+
+    accountNumberIsValid: function(accountNumber) {
+      return accountNumber.length == this.accountNumberLength() && 
+        Moip.CommonBankAccountValidator.accountNumberIsValid(accountNumber);
+    },
+
+    accountCheckNumberIsValid: function(accountCheckNumber) {
+      return Moip.CommonBankAccountValidator.accountCheckNumberIsValid(accountCheckNumber);
+    },
+
+    agencyCheckNumberMatch: function(bankAccount) {
+      return true;
+    },
+    
+    accountCheckNumberMatch: function(bankAccount) {
+      var checkNumberCalculated = Moip.BanrisulCheckNumberCalculator.calculate(bankAccount.accountNumber);
+      return checkNumberCalculated === bankAccount.accountCheckNumber;
+    },
+
+    agencyNumberMsgError: function() {
+      return Moip.CommonBankAccountValidator.agencyNumberMsgError();
+    },
+
+    agencyCheckNumberMsgError: function() {
+      return Moip.CommonBankAccountValidator.agencyCheckNumberMsgError();
+    },
+
+    accountNumberMsgError: function() {
+      return Moip.CommonBankAccountValidator.accountNumberMsgError(this.accountNumberLength());
+    },
+
+    accountNumberLength: function() { return 9; }
+    
+  };
+
+  Moip.BanrisulValidator = BanrisulValidator();
+
+})(window);


### PR DESCRIPTION
# Add Banrisul
This Pull Request adds Banrisul to the validation of bank accounts.

### How is Banrisul verification digit calculated?

1. Multiply the numbers of the bank account by the corresponding weight (Weights are: `3, 2, 4, 7, 6, 5, 4, 3, 2` in this order)
2. Sum the result
3. Get the mod of the sum by `11` (`<sum> % 11`)
4. Subtract the result of the mod by 11 (`11 - <mod>`)

 - If the mod of the sum is `0`, the verification digit is `0`.
 - If the mod of the sum is `1`, the verification digit is `6`.
 - Else, the verification digit is `11 - <mod>`